### PR TITLE
fix: fixed lint error on child

### DIFF
--- a/lib/components/ButtonGroup.tsx
+++ b/lib/components/ButtonGroup.tsx
@@ -23,7 +23,7 @@ function ButtonGroup(props: NullstackClientContext<ButtonGroupProps>) {
 
   return (
     <div class={buttonGroup({ class: klass })}>
-      {children.map((child, index) => {
+      {children.map((child: CustomChildren, index) => {
         if (!child.attributes) return child;
 
         const position = index === 0 ? "start" : index === children.length - 1 ? "end" : "middle";

--- a/lib/components/Tab.tsx
+++ b/lib/components/Tab.tsx
@@ -36,7 +36,7 @@ const Tab = ({ children, class: klass, onchange, theme }: NullstackClientContext
   return (
     <div class={klass}>
       <ul class={list()}>
-        {children.map((child, idx) => {
+        {children.map((child: CustomChildren, idx) => {
           if (!child.attributes?.title) return false;
 
           return (
@@ -51,7 +51,9 @@ const Tab = ({ children, class: klass, onchange, theme }: NullstackClientContext
           );
         })}
       </ul>
-      <div class={panel()}>{children.filter((child) => child.attributes?.active)}</div>
+      <div class={panel()}>
+        {children.filter((child: CustomChildren) => child.attributes?.active)}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
on run npm lint, was giving this error
```bash
lib/components/ButtonGroup.tsx:27:20 - error TS2339: Property 'attributes' does not exist on type 'NullstackNode'.
  Property 'attributes' does not exist on type 'string'.

27         if (!child.attributes) return child;

lib/components/Tab.tsx:40:22 - error TS2339: Property 'attributes' does not exist on type 'NullstackNode'.
  Property 'attributes' does not exist on type 'string'.

40           if (!child.attributes?.title) return false;
```